### PR TITLE
Update readme file to include installation instructions in the case o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ All of the watson-stt-wer-python dependencies are installed at once with `pip`:
 pip install -r requirements.txt
 ```
 
+**Note:**  If receiving an SSL Certificate error (CERTIFICATE_VERIFY_FAILED) when running the python scripts, try the following commands to tell python to use the system certificate store.
+
+**_Windows_**
+```
+pip install --trusted-host pypi.org --trustedhost files.python.org python-certifi-win32
+```
+
+**_MacOS_**
+
+Open a terminal Windows and change to the location of your python installation
+```
+cd /Applications/Python 3.6
+./Install Certificates.command
+```
+
 ## Setup
 Create a copy of `config.ini.sample`. You'll modify this file in subsequent steps.
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install --trusted-host pypi.org --trustedhost files.python.org python-certif
 
 **_MacOS_**
 
-Open a terminal Windows and change to the location of your python installation
+Open a terminal and change to the location of your python installation to execute `Install Certificates.command`, for example:
 ```
 cd /Applications/Python 3.6
 ./Install Certificates.command


### PR DESCRIPTION
Closes Issue #28

Added comments for windows and MacOS to configure Python to use the system certificate store.

DCO 1.1 Signed-off-by: Leo Mazzoli lmazzoli@us.ibm.com