### PR TITLE
expose low_latency variable

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -11,6 +11,7 @@ inactivity_timeout=-1
 speech_detector_sensitivity=0.5
 background_audio_suppression=0.0
 smart_formatting=False
+low_latency=False
 ;customization_weight=0.3
 
 #At most one of interim_results and audio_metrics can be True

--- a/transcribe.py
+++ b/transcribe.py
@@ -111,6 +111,7 @@ class Transcriber:
         interim_results              = self.config.getBoolean("SpeechToText", "interim_results")
         audio_metrics                = self.config.getBoolean("SpeechToText", "audio_metrics")
         smart_formatting             = self.config.getBoolean("SpeechToText", "smart_formatting")
+        low_latency                  = self.config.getBoolean("SpeechToText", "low_latency")
 
         callback = MyRecognizeCallback(filename, self.transcriptions)
 
@@ -128,6 +129,7 @@ class Transcriber:
                 speech_detector_sensitivity=speech_detector_sensitivity,
                 background_audio_suppression=background_audio_suppression,
                 smart_formatting=smart_formatting,
+                low_latency=low_latency,
                 customization_weight=customization_weight,
                 #At most one of interim_results and audio_metrics can be True
                 interim_results=interim_results,


### PR DESCRIPTION
Fixes #30 

Exposes `low_latency` parameter with default value of `False`.

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>