### PR TITLE
quick fix - freeze to JIWER 2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ibm_watson>=4.7.1
-jiwer>=2.2.0
+jiwer==2.2.0
 configparser>=5.0.0
 pandas>=1.0.5
 nltk>=3.4.5


### PR DESCRIPTION
Workaround for #34. (I prefer a more permanent solution later)
Hardcode to JIWER 2.2.0 while the JIWER 2.3.0 api is not compatible.