### PR TITLE
support JIWER 2.2.0 and 2.3.0 API simultaneously

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -152,13 +152,14 @@ class Analyzer:
         if self.config.getBoolean("Transformations", "lower_case"):
             pipeline.append(jiwer.ToLowerCase())
 
-        if self.config.getBoolean("Transformations", "remove_multiple_spaces"):
-            pipeline.append(jiwer.RemoveMultipleSpaces())
-
         if self.config.getBoolean("Transformations", "remove_white_space"):
             pipeline.append(jiwer.RemoveWhiteSpace(replace_by_space=True))
 
-        if self.config.getBoolean("Transformations", "sentences_to_words"):
+        if self.config.getBoolean("Transformations", "remove_multiple_spaces"):
+            pipeline.append(jiwer.RemoveMultipleSpaces())
+
+        #JIWER 2.2 defines SentencesToListOfWords
+        if self.config.getBoolean("Transformations", "sentences_to_words") and getattr(jiwer, "SentencesToListOfWords", None) is not None:
             pipeline.append(jiwer.SentencesToListOfWords(word_delimiter=" "))
 
         word_list = self.config.getValue("Transformations", "remove_word_list")
@@ -173,6 +174,11 @@ class Analyzer:
 
         if self.config.getBoolean("Transformations", "remove_empty_strings"):
             pipeline.append(jiwer.RemoveEmptyStrings())
+
+        #JIWER 2.3+ defines ReduceToListOfListOfWords, breaking API change from SentencesToListOfWords
+        if self.config.getBoolean("Transformations", "sentences_to_words") and getattr(jiwer, "ReduceToListOfListOfWords", None) is not None:
+            pipeline.append(jiwer.ReduceToSingleSentence())
+            pipeline.append(jiwer.ReduceToListOfListOfWords(word_delimiter=" "))
 
         return jiwer.Compose(pipeline)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ibm_watson>=4.7.1
-jiwer==2.2.0
+jiwer>=2.2.0
 configparser>=5.0.0
 pandas>=1.0.5
 nltk>=3.4.5


### PR DESCRIPTION
Fixes #34.

1) Fixed nonsensical ordering of `remove_multiple_spaces` and `remove_white_space`
2) Detect which JIWER methods are available:
  a) If `SentencesToListOfWords` exists, we are in 2.2.0 and should do that transform in middle of pipeline
  b) If `ReduceToListOfListOfWords` exists, we are in 2.3.0 and should do `ReduceToSingleSentence` then `ReduceToListOfListOfWords` at the end of the pipeline.
3) Restore `requirements.txt` to allow any compatible version of JIWER.

Thanks to JIWER author @nikvaessen for the suggestions!

DCO 1.1 Signed-off-by: Andrew R. Freed [afreed@us.ibm.com](mailto:afreed@us.ibm.com)