### PR TITLE
force jiwer 2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ibm_watson>=4.7.1
-jiwer>=2.2.0
+jiwer==2.2.0
 configparser>=5.0.0
 pandas>=1.0.5
 nltk>=3.4.5


### PR DESCRIPTION
fix for [issue 39...](https://github.com/IBM/watson-stt-wer-python/issues/39)

jiwer 2.3.0 is creating a list of list in `analyze`

```
cleaned_ref:
[['ibuprofen', 'is', 'good', 'for', 'your', 'muscle', 'aches']]
cleaned_hyp
[['id', 'be', 'profane', 'is', 'good', 'for', 'your', 'muscle', 'aches']]
```

which results in an error...
```
[I] ➜ python3 analyze.py
Using default config filename: config.ini.
Traceback (most recent call last):
  File "/Users/tnixa/watson/sandbox/python-virtual-environments/watson-stt-wer-python/analyze.py", line 258, in <module>
    main()
  File "/Users/tnixa/watson/sandbox/python-virtual-environments/watson-stt-wer-python/analyze.py", line 252, in main
    results = analyzer.analyze()
  File "/Users/tnixa/watson/sandbox/python-virtual-environments/watson-stt-wer-python/analyze.py", line 216, in analyze
    measures = jiwer.compute_measures(cleaned_ref, cleaned_hyp)
  File "/usr/local/lib/python3.9/site-packages/jiwer/measures.py", line 209, in compute_measures
    truth, hypothesis = _preprocess(
  File "/usr/local/lib/python3.9/site-packages/jiwer/measures.py", line 321, in _preprocess
    transformed_truth = truth_transform(truth)
  File "/usr/local/lib/python3.9/site-packages/jiwer/transforms.py", line 76, in __call__
    text = tr(text)
  File "/usr/local/lib/python3.9/site-packages/jiwer/transforms.py", line 55, in __call__
    return self.process_list(sentences)
  File "/usr/local/lib/python3.9/site-packages/jiwer/transforms.py", line 202, in process_list
    return [self.process_string(s) for s in inp]
  File "/usr/local/lib/python3.9/site-packages/jiwer/transforms.py", line 202, in <listcomp>
    return [self.process_string(s) for s in inp]
  File "/usr/local/lib/python3.9/site-packages/jiwer/transforms.py", line 199, in process_string
    return re.sub(r"\s\s+", " ", s)
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

jiwer 2.2.0 version does not have this problem so proposing to change the requirements to force the version to 2.2.0