### PR TITLE
Adding support for new STT parameters

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,14 +13,14 @@ class Config:
         self.config = configparser.ConfigParser(interpolation=None)
         self.config.read(config_file)
 
-    def getBoolean(self, section, key):
-        return self.getValue(section, key) == "True"
+    def getBoolean(self, section, key, default_value=None):
+        return self.getValue(section, key, default_value) == "True"
 
-    def getValue(self, section, key):
+    def getValue(self, section, key, default_value=None):
         value = None
         if section in self.config:
            list = self.config[section]
-           value = list.get(key, None)
+           value = list.get(key, default_value)
         return value
 
     def getKeys(self, section):

--- a/experiment.py
+++ b/experiment.py
@@ -63,17 +63,29 @@ def run_all_experiments(config_file, output_dir):
     #that need to be tested
 
     #Set variable for stt configuration to iterate through
-    sensitivity = 0.3
+#    customization_weight = 0.1
+    character_insertion_bias = 0.0
+#    background_audio_suppression = 0.0
+#    speech_detector_sensitivity = 0.0
 
     #Iterate through possible values of the setting.
-    while sensitivity < 0.5:
+#    while customization_weight < 1.0:
+    while character_insertion_bias < 1.0:
+#    while background_audio_suppression < 1.0:
+#    while speech_detector_sensitivity < 1.0:
 
         #Run the experiment for the specific configuration value
         #You must include the exact name of the stt parameter being tested
-        run_experiment(config_file, output_dir, "speech_detector_sensitivity", sensitivity)
+#        run_experiment(config_file, output_dir, "customization_weight", customization_weight)
+        run_experiment(config_file, output_dir, "character_insertion_bias", character_insertion_bias)
+#        run_experiment(config_file, output_dir, "background_audio_suppression", background_audio_suppression)
+#        run_experiment(config_file, output_dir, "speech_detector_sensitivity", speech_detector_sensitivity)
 
         #Move to the next value to be tested
-        sensitivity = sensitivity + 0.1
+#        customization_weight = customization_weight + 0.1
+        character_insertion_bias = character_insertion_bias + 0.05
+#        background_audio_suppression = background_audio_suppression + 0.05
+#        speech_detector_sensitivity = speech_detector_sensitivity + 0.05
 
 
 def run_report(output_dir, config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ibm_watson>=4.7.1
+ibm_watson>=6.1
 jiwer==2.2.0
 configparser>=5.0.0
 pandas>=1.0.5

--- a/transcribe.py
+++ b/transcribe.py
@@ -104,7 +104,7 @@ class Transcriber:
         inactivity_timeout           =   int(self.config.getValue("SpeechToText", "inactivity_timeout"))
         speech_detector_sensitivity  = float(self.config.getValue("SpeechToText", "speech_detector_sensitivity"))
         background_audio_suppression = float(self.config.getValue("SpeechToText", "background_audio_suppression"))
-        character_insertion_bias     = float(self.config.getValue("SpeechToText", "character_insertion_bias"))
+        character_insertion_bias     = float(self.config.getValue("SpeechToText", "character_insertion_bias", 0.0))
         if language_customization_id is not None:
             customization_weight         = float(self.config.getValue("SpeechToText", "customization_weight"))
         else:

--- a/transcribe.py
+++ b/transcribe.py
@@ -104,6 +104,7 @@ class Transcriber:
         inactivity_timeout           =   int(self.config.getValue("SpeechToText", "inactivity_timeout"))
         speech_detector_sensitivity  = float(self.config.getValue("SpeechToText", "speech_detector_sensitivity"))
         background_audio_suppression = float(self.config.getValue("SpeechToText", "background_audio_suppression"))
+        character_insertion_bias     = float(self.config.getValue("SpeechToText", "character_insertion_bias"))
         if language_customization_id is not None:
             customization_weight         = float(self.config.getValue("SpeechToText", "customization_weight"))
         else:
@@ -114,6 +115,7 @@ class Transcriber:
         audio_metrics                = self.config.getBoolean("SpeechToText", "audio_metrics")
         smart_formatting             = self.config.getBoolean("SpeechToText", "smart_formatting")
         low_latency                  = self.config.getBoolean("SpeechToText", "low_latency")
+        skip_zero_len_words          = self.config.getBoolean("SpeechToText", "skip_zero_len_words")
 
         callback = MyRecognizeCallback(filename, self.transcriptions)
 
@@ -132,6 +134,8 @@ class Transcriber:
                 background_audio_suppression=background_audio_suppression,
                 smart_formatting=smart_formatting,
                 low_latency=low_latency,
+                skip_zero_len_words=skip_zero_len_words,
+                character_insertion_bias=character_insertion_bias,
                 customization_weight=customization_weight,
                 #At most one of interim_results and audio_metrics can be True
                 interim_results=interim_results,


### PR DESCRIPTION
Adding support for character_insertion_bias and skip_zero_len_words (dark parameter)

Updated the transcribe.py and experiment.py files with commented lines (as examples) of doing experimentations with common parameters

DCO 1.1 Signed-off-by: Marco Noel <marco.noel@ca.ibm.com>