### PR TITLE
add stuff to be able to reset custom model

### DIFF
--- a/models.py
+++ b/models.py
@@ -113,6 +113,7 @@ class ModelTool:
         # Update intentionally mapped to STT 'train' to reduce operation count.  
         # Thus the SDK's 'add' is our 'create' and SDK's 'train' is our update.  This matches my mental model of speech customization.
         handlers['update'] = self.train_custom_model
+        handlers['reset'] = self.reset_custom_model
 
         return handlers
 
@@ -313,7 +314,7 @@ class ModelTool:
 def create_parser():
     parser = ArgumentParser(description='Run IBM Speech To Text model-related commands')
     parser.add_argument('-c', '--config_file', type=str, required=False, default="config.ini", help='Configuration file including connection details')
-    parser.add_argument('-o', '--operation', type=str, required=True, choices=["list","get","create","update","delete"], help="operation to perform")
+    parser.add_argument('-o', '--operation', type=str, required=True, choices=["list","get","create","update","delete","reset"], help="operation to perform")
     parser.add_argument('-t', '--type', type=str, required=True, choices=["base_model","custom_model","corpus","word","grammar"], help="type the operation works on")
     parser.add_argument('-n', '--name', type=str, required=False, help="name the operation works on, for instance 'MyModel' or 'corpus1'.")
     parser.add_argument('-d', '--description', type=str, required=False, help="description of the object being created; used only in create")


### PR DESCRIPTION
small change to add stuff to be able to use the existing custom model reset function

test results:
```
10:26:03 in ~/watson/sandbox/reset/watson-stt-wer-python on  tnixa-reset [!?] via 🐍 3.9.11 took 6s
[I] ➜ python models.py -c config-other-test.ini -o list -t corpora
usage: models.py [-h] [-c CONFIG_FILE] -o {list,get,create,update,delete,reset} -t {base_model,custom_model,corpus,word,grammar} [-n NAME] [-d DESCRIPTION]
                 [-f FILE]
models.py: error: argument -t/--type: invalid choice: 'corpora' (choose from 'base_model', 'custom_model', 'corpus', 'word', 'grammar')

10:26:29 in ~/watson/sandbox/reset/watson-stt-wer-python on  tnixa-reset [!?] via 🐍 3.9.11
[I] ➜ python models.py -c config-other-test.ini -o list -t corpus
Executing operation: list on type: corpus
{
  "corpora": []
}
```

DCO 1.1 Signed-off-by: Terrence Nixa - [tnixa@us.ibm.com](mailto:tnixa@us.ibm.com)
