### PR TITLE
changes for threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Required configuration parameters:
 * base_model_name - Base model for Speech to Text transcription
 
 Optional configuration parameters:
+* max_threads - Maximum number of threads to use with `transcribe.py` to improve performance. 
 * language_model_id - Language model customization ID (comment out to use base model)
 * acoustic_model_id - Acoustic model customization ID (comment out to use base model)
 * grammar_name - Grammar name (comment out to use base model)

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -2,7 +2,9 @@
 apikey=xxxxxxxxx-xxxxx-xxxxx-xxxxxxxxxxx # pragma: allowlist secret
 service_url=https://....
 use_bearer_token=False
+
 ;max_threads=20
+
 base_model_name=en-US_Telephony
 ;language_model_id=xxxxxxxxx-xxxxx-xxxxx-xxxxxxxxxxx
 ;grammar_name=

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -2,6 +2,7 @@
 apikey=xxxxxxxxx-xxxxx-xxxxx-xxxxxxxxxxx # pragma: allowlist secret
 service_url=https://....
 use_bearer_token=False
+;max_threads=20
 base_model_name=en-US_Telephony
 ;language_model_id=xxxxxxxxx-xxxxx-xxxxx-xxxxxxxxxxx
 ;grammar_name=

--- a/transcribe.py
+++ b/transcribe.py
@@ -223,7 +223,7 @@ def run(config_file:str):
         os.makedirs(output_dir, exist_ok=True)
 
     files = [audio_file_dir + "/" + f for f in os.listdir(audio_file_dir)]
-    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_threads) as executor:
         executor.map(transcriber.transcribe,files)
 
     transcriber.report()


### PR DESCRIPTION
Threading changes to improve performance with `transcribe.py`
Test results:
```
Transcribe 843 audios in audio.otherM1M2Filtered...
Without threading: 42 minutes
5 threads: 12 minutes
10 threads: 6 minutes
20 threads: 4 minutes
40 threads: 2 minutes
80 threads: 1 minute
100 threads: 1 minute
120 threads: many errors
160 threads: many errors

Transcribe same 843 audios using chatty and tuner scripts from speech dev team...
chatty with 20 threads: 4 minutes
chatty with 40 threads: 2 minutes
chatty with 80 threads: 2 minutes
```


Signed-off-by: Terrence Nixa <tnixa@us.ibm.com>
DCO 1.1 Signed-off-by: Terrence Nixa - [tnixa@us.ibm.com](mailto:tnixa@us.ibm.com)