### PR TITLE
#59 type conversion on max_threads to int

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -213,10 +213,7 @@ def run(config_file:str):
     transcriber = Transcriber(config)
 
     audio_file_dir    = config.getValue("Transcriptions","audio_file_folder")
-    max_threads   = config.getValue("SpeechToText","max_threads")
-    if max_threads is None:
-        max_threads=1
-    print("max_threads: ", max_threads)
+    max_threads   = int(config.getValue("SpeechToText","max_threads", 1))
 
     output_dir = os.path.dirname(config.getValue("ErrorRateOutput", "summary_file"))
     if output_dir is not None and len(output_dir) > 0:


### PR DESCRIPTION
Fixes #59 

Removes conditional branch by adding default value and always converts to int.

Signed-off-by: Andrew R Freed <afreed@us.ibm.com>