### PR TITLE
Perform basic grid search in experiment.py and standardize logging across involved scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Utilities for
 * [Transcribing](#transcription) a set of audio files with Speech to Text (STT)
 * [Analyzing](#analysis) the error rate of the STT transcription against a known-good transcription
+* [Experimenting](#experimenting) with various parameters to find optimal values
 
 ## More documentation
 This readme describes the tools in depth.  For more information on use cases and methodology, please see the following articles:
@@ -74,7 +75,7 @@ Optional configuration parameters:
 Assuming your configuration is in `config.ini`, transcribe all the audio files in `audio_file_folder` parameter via the following command:
 
 ```
-python transcribe.py config.ini
+python transcribe.py --config_file config.ini --log_level DEBUG
 ```
 
 ## Output
@@ -96,23 +97,10 @@ Your config file must have references for the `reference_transcriptions_file` an
 * **Reference file** (`reference_transcriptions_file`) is a CSV file with at least columns called `Audio File Name` and `Reference`.  The `Reference` is the actual transcription of the audio file (also known as the "ground truth" or "labeled data"). NOTE: In your audio file name, make sure you put the full path (eg. ./audio1.wav)
 * **Hypothesis file** (`stt_transcriptions_file`) is a CSV file with at least columns called `Audio File Name` and `Hypothesis`.  The `Hypothesis` is the transcription of the audio file by the Speech to Text engine.  The `transcribe.py` script can create this file.
 
-## Execution
-
-```
-python analyze.py config.ini
-```
-
-# Experiment
-Use the experiment.py script to execute a series of Transcription/Analyze experiments where configuration settings may change for each experiment.  This option will require customization to set up for the specific configuration to be tested.  Changes should be made in the run_all_experiments function.
-
-```
-python experiment.py config.ini
-```
-
 ## Results
-The script creates two output files, in the file names specified by the `details_file` and `summary_file` properties.
 * **Details** (`details_file`) is a CSV file with rows for each audio sample, including reference and hypothesis transcription and specific transcription errors
 * **Summary** (`summary_file`) is a JSON file with metrics for total transcriptions and overall word and sentence error rates.
+* **Accuracy** (`word_accuracy_file`) is a CSV file with rows
 
 ## Metrics (Definitions)
 - WER (word error rate), commonly used in ASR assessment, measures the cost of restoring the output word sequence to the original input sequence.
@@ -124,6 +112,40 @@ Repo of the Python module JIWER: https://pypi.org/project/jiwer/
 
 It computes the minimum-edit distance between the ground-truth sentence and the hypothesis sentence of a speech-to-text API.
 The minimum-edit distance is calculated using the python C module python-Levenshtein.
+
+## Execution
+
+```
+python analyze.py --config_file config.ini --log_level DEBUG
+```
+
+# Experimenting
+Use the `experiment.py` script to execute a series of Transcription/Analyze experiments to optimize SpeechToText parameters. 
+
+## Setup
+
+Follow the setup for [Transcribing](#transcription).
+
+Follow the setup for [Analyzing](#analysis).
+
+The following parameters in `[Experiments]` all have a `*_min` and `*_max` variant to specify the lower limit and upper limit, respectively, for its corresponding `[SpeechToText]` parameter, and a `*_step` variant to specify the amount to increase that parameter in each experiment:
+1. `sds_*` controls the `speech_detector_sensitivity` parameter
+1. `bias_*` controls the `character_insertion_bias` parameter
+1. `cust_weight_*` controls the `customization_weight` parameter
+1. `bas_*` controls the `background_audio_suppression`parameter
+
+## Execution
+
+```
+python experiment.py --config_file config.ini --log_level INFO
+```
+
+## Results
+Each experiment creates a unique directory based on the parameters of that experiment in the format `bias + "_" + weight + "_" + sds + "_" + bas`.
+
+For each experiment the output files from [Transcribing](#transcription) and [Analyzing](#analysis) will be created in its unique output directory. 
+
+There will be a final file created called `all_summaries.csv` that contains the summary of all experiments in a single CSV.   
 
 # Model training
 The `models.py` script has wrappers for many model-related tasks including creating models, updating training contents, getting model details, and training models.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ cp config.ini.sample config.ini
 
 Each sub-sections will describe what configuration parameters are needed.
 
+# Generic Command-Line parameters
+
+`--config_file` or `-c` is the configuration file to be used. The default is `config.ini`
+
+`--log_level` or `-ll` is the log level to be used when running the script. Supported levels are as follows:
+- `ERROR` -- Print out only when things fail.
+- `WARN` -- Print out cautions and when things fail.
+- `INFO` -- (Default) Print out useful status, cautions, and when things fail.
+- `DEBUG` -- Print out every possible message.
+
 # Transcription
 Uses IBM Watson Speech to Text service to transcribe a folder full of audio files.  Creates a CSV with transcriptions.
 
@@ -77,6 +87,8 @@ Assuming your configuration is in `config.ini`, transcribe all the audio files i
 ```
 python transcribe.py --config_file config.ini --log_level DEBUG
 ```
+
+See [Generic Command Line Parameters](#generic-command-line-parameters) for more details.
 
 ## Output
 Transcription will be stored in a CSV file based on `stt_transcriptions_file` parameter with a format like below:
@@ -119,6 +131,8 @@ The minimum-edit distance is calculated using the python C module python-Levensh
 python analyze.py --config_file config.ini --log_level DEBUG
 ```
 
+See [Generic Command Line Parameters](#generic-command-line-parameters) for more details.
+
 # Experimenting
 Use the `experiment.py` script to execute a series of Transcription/Analyze experiments to optimize SpeechToText parameters. 
 
@@ -139,6 +153,8 @@ The following parameters in `[Experiments]` all have a `*_min` and `*_max` varia
 ```
 python experiment.py --config_file config.ini --log_level INFO
 ```
+
+See [Generic Command Line Parameters](#generic-command-line-parameters) for more details.
 
 ## Results
 Each experiment creates a unique directory based on the parameters of that experiment in the format `bias + "_" + weight + "_" + sds + "_" + bas`.

--- a/analyze.py
+++ b/analyze.py
@@ -258,10 +258,10 @@ def run(config_file:str, logging_level:str=DEFAULT_LOGLEVEL):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '-c', '--config', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
+        '-c', '--config_file', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
     parser.add_argument(
-        '-ll', '--log-level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
+        '-ll', '--log_level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
 
     args = parser.parse_args()
 
-    run(args.config, args.log_level)
+    run(args.config_file, args.log_level)

--- a/analyze.py
+++ b/analyze.py
@@ -109,7 +109,6 @@ class AnalysisResults:
         return results
 
     def write_details(self, filename):
-        logging.debug(f"Writing detailed results to {filename}")
         csv_columns = self.headers
 
         with open(filename, 'w') as csvfile:
@@ -117,15 +116,17 @@ class AnalysisResults:
             writer.writerow(csv_columns)
             for result in self.results:
                 writer.writerow(result.data.values())
+        
+        logging.info(f"Wrote detailed results to {filename}")
 
     def write_summary(self, filename):
-        logging.debug(f"Writing summary results to {filename}")
 
         with open(filename, 'w') as jsonfile:
             json.dump(self.get_summary(), jsonfile, indent=2)
+        
+        logging.info(f"Wrote summary results to {filename}")
 
     def write_word_accuracy(self, filename):
-        logging.debug(f"Writing word accuracy results to {filename}")
         csv_columns = ['word','count','errors','error_rate']
 
         with open(filename, 'w') as csvfile:
@@ -133,6 +134,8 @@ class AnalysisResults:
             writer.writeheader()
             for word in self.word_map:
                 writer.writerow(self.word_map[word])
+
+        logging.info(f"Wrote word accuracy results to {filename}")
 
 class Analyzer:
     def __init__(self, config):

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -51,3 +51,17 @@ strip=True
 remove_empty_strings=True
 ;If True, pre-processing stems words with Porter stemmer. Stemming will treat singular/plural of a word as equivalent, rather than a word error.
 stemming=False
+
+[Experiments]
+sds_min=0.5
+sds_max=0.5
+sds_step=0.1
+bias_min=0
+bias_max=0.0
+bias_step=0.1
+cust_weight_min=0
+cust_weight_max=0.3
+cust_weight_step=0.1
+bas_min=0
+bas_max=0.0
+bas_step=0.1

--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ class Config:
     def __init__(self, config_file:str):
         # (interpolation=None) so that '%' is not treated like an environment variable
          # inline_comment_prefixes allows comments inline, after the value
+        self.config_file = config_file
         self.config = configparser.ConfigParser(interpolation=None, inline_comment_prefixes='#;')
         self.config.read(config_file)
 

--- a/experiment.py
+++ b/experiment.py
@@ -33,6 +33,12 @@ class Experiments:
             for weight in weight_values:
                 for sds in sds_values:
                     for bas in bas_values:
+
+                        bias = round(bias, 2)
+                        weight = round(weight, 2)
+                        sds = round(sds, 2)
+                        bas = round(bas,2)
+
                         logging.info(f"Running Experiment -- Character Insertion Bias: {bias}, Customization Weight: {weight}, Speech Detector Sensitivity: {sds}, Background Audio Suppression: {bas}")
 
                         experiment_output_dir = self.output_dir + "/" + str(bias) + "_" + str(weight) + "_" + str(sds) + "_" + str(bas)
@@ -142,7 +148,7 @@ def run(config_file:str, logging_level:str=DEFAULT_LOGLEVEL):
     custom_model = str(config.getValue("SpeechToText", "language_model_id"))
     
     bias_range = drange(bias_min, bias_max+bias_step, bias_step)
-    weight_range = drange(cust_weight_min, cust_weight_max+cust_weight_step, cust_weight_step) if custom_model else drange(0.0, 0.1, 0.1)
+    weight_range = drange(cust_weight_min, cust_weight_max+cust_weight_step, cust_weight_step) if custom_model==None else drange(0.0, 0.1, 0.1)
     sds_range = drange(sds_min, sds_max+sds_step, sds_step) 
     bas_range = drange(bas_min, bas_max+bas_step, bas_step)
     

--- a/experiment.py
+++ b/experiment.py
@@ -33,8 +33,6 @@ class Experiments:
             for weight in weight_values:
                 for sds in sds_values:
                     for bas in bas_values:
-                        bias = round(bias,1)
-                        weight = round(weight, 1)
                         logging.info(f"Running Experiment -- Character Insertion Bias: {bias}, Customization Weight: {weight}, Speech Detector Sensitivity: {sds}, Background Audio Suppression: {bas}")
 
                         experiment_output_dir = self.output_dir + "/" + str(bias) + "_" + str(weight) + "_" + str(sds) + "_" + str(bas)

--- a/experiment.py
+++ b/experiment.py
@@ -28,42 +28,47 @@ class Experiments:
             for weight in weight_values:
                 for sds in sds_values:
                     for bas in bas_values:
-                        counter=0
                         bias = round(bias,1)
                         weight = round(weight, 1)
                         print(bias, weight, sds, bas)
 
-                        experiment_output_dir = self.output_dir + "/" + bias + "_" + weight + "_" + sds + "_" + bas
+                        experiment_output_dir = self.output_dir + "/" + str(bias) + "_" + str(weight) + "_" + str(sds) + "_" + str(bas)
                         os.makedirs(experiment_output_dir, exist_ok=True)
 
-                        exp_config_path = experiment_output_dir + "/" + self.config
-                        copyfile(self.config, exp_config_path)
+                        exp_config_path = experiment_output_dir + "/" + self.config.config_file
+                        copyfile(self.config.config_file, exp_config_path)
 
                         #Update config settings for the experiment
                         exp_config = Config(exp_config_path)
 
                         file_info = os.path.split(exp_config.getValue('ErrorRateOutput', 'details_file'))
-                        details_file = os.path.join(file_info[0], experiment_output_dir, file_info[1])
+                        details_file = os.path.join(experiment_output_dir, file_info[1])
                         exp_config.setValue('ErrorRateOutput', 'details_file', details_file)
 
                         file_info = os.path.split(exp_config.getValue('ErrorRateOutput', 'summary_file'))
-                        details_file = os.path.join(file_info[0], experiment_output_dir, file_info[1])
-                        exp_config.setValue('ErrorRateOutput', 'summary_file', details_file)
+                        summary_file = os.path.join(experiment_output_dir, file_info[1])
+                        exp_config.setValue('ErrorRateOutput', 'summary_file', summary_file)
 
                         file_info = os.path.split(exp_config.getValue('ErrorRateOutput', 'word_accuracy_file'))
-                        details_file = os.path.join(file_info[0], experiment_output_dir, file_info[1])
-                        exp_config.setValue('ErrorRateOutput', 'word_accuracy_file', details_file)
+                        word_accuracy_file = os.path.join(experiment_output_dir, file_info[1])
+                        exp_config.setValue('ErrorRateOutput', 'word_accuracy_file', word_accuracy_file)
 
                         file_info = os.path.split(exp_config.getValue('Transcriptions', 'stt_transcriptions_file'))
-                        details_file = os.path.join(file_info[0], experiment_output_dir, file_info[1])
-                        exp_config.setValue('Transcriptions', 'stt_transcriptions_file', details_file)
-                                                
-                        exp_config.setValue('SpeechToText', "max_threads", int(max_threads))
+                        stt_transcriptions_file = os.path.join(experiment_output_dir, file_info[1])
+                        exp_config.setValue('Transcriptions', 'stt_transcriptions_file', stt_transcriptions_file)
 
-                        exp_config.setValue('SpeechToText', "speech_detector_sensitivity", float(sds))
-                        exp_config.setValue('SpeechToText', "background_audio_suppression", float(bas))
-                        exp_config.setValue('SpeechToText', "character_insertion_bias", float(bias))
-                        exp_config.setValue('SpeechToText', "customization_weight", float(weight))
+                        file_info = os.path.split(exp_config.getValue('ErrorRateOutput', 'stt_transcriptions_file'))
+                        stt_transcriptions_file = os.path.join(experiment_output_dir, file_info[1])
+                        exp_config.setValue('ErrorRateOutput', 'stt_transcriptions_file', stt_transcriptions_file)
+                                                
+                        exp_config.setValue('SpeechToText', "max_threads", str(max_threads))
+
+                        exp_config.setValue('SpeechToText', "speech_detector_sensitivity", str(sds))
+                        exp_config.setValue('SpeechToText', "background_audio_suppression", str(bas))
+                        exp_config.setValue('SpeechToText', "character_insertion_bias", str(bias))
+                        exp_config.setValue('SpeechToText', "customization_weight", str(weight))
+
+                        exp_config.writeFile(exp_config_path)
 
                         #Get Transcriptions 
                         transcribe.run(exp_config_path)
@@ -71,7 +76,9 @@ class Experiments:
                         #Get Analysis
                         analyze.run(exp_config_path)
 
-    def run_report(output_dir, config):
+
+
+    def run_report(self, output_dir, config):
         print(f"Reporting from {output_dir}")
 
         # Extract all summaries
@@ -117,30 +124,29 @@ def main():
     # build generators
     experiments = Experiments(config, output_dir)
     max_threads = int(config.getValue("SpeechToText","max_threads", 1))
-    sds_min  = float(config.getValue("SpeechToText", "sds_min"))
-    sds_max  = float(config.getValue("SpeechToText", "sds_max"))
-    sds_step  = float(config.getValue("SpeechToText", "sds_step"))
-    bias_min  = float(config.getValue("SpeechToText", "bias_min"))
-    bias_max  = float(config.getValue("SpeechToText", "bias_max"))
-    bias_step  = float(config.getValue("SpeechToText", "bias_step"))
-    cust_weight_min  = float(config.getValue("SpeechToText", "cust_weight_min"))
-    cust_weight_max  = float(config.getValue("SpeechToText", "cust_weight_max"))
-    cust_weight_step  = float(config.getValue("SpeechToText", "cust_weight_step"))
-    bas_min = float(config.getValue("SpeechToText", "bas_min"))
-    bas_max = float(config.getValue("SpeechToText", "bas_max"))
-    bas_step = float(config.getValue("SpeechToText", "bas_step"))
+    sds_min  = float(config.getValue("Experiments", "sds_min"))
+    sds_max  = float(config.getValue("Experiments", "sds_max"))
+    sds_step  = float(config.getValue("Experiments", "sds_step"))
+    bias_min  = float(config.getValue("Experiments", "bias_min"))
+    bias_max  = float(config.getValue("Experiments", "bias_max"))
+    bias_step  = float(config.getValue("Experiments", "bias_step"))
+    cust_weight_min  = float(config.getValue("Experiments", "cust_weight_min"))
+    cust_weight_max  = float(config.getValue("Experiments", "cust_weight_max"))
+    cust_weight_step  = float(config.getValue("Experiments", "cust_weight_step"))
+    bas_min = float(config.getValue("Experiments", "bas_min"))
+    bas_max = float(config.getValue("Experiments", "bas_max"))
+    bas_step = float(config.getValue("Experiments", "bas_step"))
 
-    base_model_name = str(config.getValue("SpeechToText", "base_model_name"))
     custom_model = str(config.getValue("SpeechToText", "language_model_id"))
     
-    bias_range = drange(bias_min, bias_max+bias_step, bias_step) if base_model_name.find('bandModel') == -1 else drange(0.0, 0.1, 0.1)
+    bias_range = drange(bias_min, bias_max+bias_step, bias_step)
     weight_range = drange(cust_weight_min, cust_weight_max+cust_weight_step, cust_weight_step) if custom_model else drange(0.0, 0.1, 0.1)
     sds_range = drange(sds_min, sds_max+sds_step, sds_step) 
     bas_range = drange(bas_min, bas_max+bas_step, bas_step)
     
     experiments.run_all_experiments(bias_range, weight_range, sds_range, bas_range, max_threads)
 
-    run_report(output_dir, config)
+    experiments.run_report(output_dir, config)
 
 if __name__ == '__main__':
     main()

--- a/experiment.py
+++ b/experiment.py
@@ -155,10 +155,10 @@ def run(config_file:str, logging_level:str=DEFAULT_LOGLEVEL):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '-c', '--config', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
+        '-c', '--config_file', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
     parser.add_argument(
-        '-ll', '--log-level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
+        '-ll', '--log_level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
 
     args = parser.parse_args()
 
-    run(args.config, args.log_level)
+    run(args.config_file, args.log_level)

--- a/transcribe.py
+++ b/transcribe.py
@@ -242,10 +242,10 @@ def run(config_file:str, logging_level:str=DEFAULT_LOGLEVEL):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '-c', '--config', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
+        '-c', '--config_file', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
     parser.add_argument(
-        '-ll', '--log-level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
+        '-ll', '--log_level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
 
     args = parser.parse_args()
 
-    run(args.config, args.log_level)
+    run(args.config_file, args.log_level)

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import argparse
 import json
 import os
 import sys
@@ -7,6 +8,7 @@ import csv
 import concurrent.futures
 import threading
 from config import Config
+import logging
 
 from ibm_watson import SpeechToTextV1
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
@@ -20,6 +22,9 @@ from os import path
 import pandas as pd
 
 from uuid import uuid4
+
+DEFAULT_CONFIG_INI='config.ini'
+DEFAULT_LOGLEVEL='DEBUG'
 
 class Transcriptions:
     data = {}
@@ -48,13 +53,13 @@ class MyRecognizeCallback(RecognizeCallback):
             #print(transcription)
             self.transcriptions.add(self.audio_file_name, transcription)
         except:
-            print(f"{self.audio_file_name} - No transcription found", sys.stderr)
+            logging.exception(f"{self.audio_file_name} - No transcription found")
 
     def on_error(self, error):
-        print(f'{self.audio_file_name} - Recognize Error received: {error}', file=sys.stderr)
+        logging.error(f'{self.audio_file_name} - Recognize Error received: {error}')
 
     def on_inactivity_timeout(self, error):
-        print(f'{self.audio_file_name} - Inactivity timeout: {error}', file=sys.stderr)
+        logging.error(f'{self.audio_file_name} - Inactivity timeout: {error}')
 
 class Transcriber:
 
@@ -96,7 +101,7 @@ class Transcriber:
             return None
 
     def transcribe(self, filename):
-        print(f"Transcribing from {filename}")
+        logging.debug(f"Transcribing from {filename}")
 
         #Model connection configs
         base_model                = self.config.getValue("SpeechToText", "base_model_name")
@@ -130,7 +135,7 @@ class Transcriber:
             new_headers=self.STT.default_headers
             new_headers['X-Global-Transaction-Id']=transaction_id
             self.STT.set_default_headers(new_headers)
-            print("--> Transaction ID:", self.STT.default_headers['X-Global-Transaction-Id'])
+            logging.deubg("--> Transaction ID:", self.STT.default_headers['X-Global-Transaction-Id'])
 
         #print(f"Requesting transcription of {filename}")
         with open(filename, "rb") as audio_file:
@@ -157,7 +162,7 @@ class Transcriber:
                 )
                 #print(f"Requested transcription of {filename}")
             except Exception as e:
-                print(f"Error transcribing {filename}:",e)
+                logging.exception(f"Error transcribing {filename}:",exc_info=e)
 
     def report(self):
         report_file_name = self.config.getValue("Transcriptions", "stt_transcriptions_file")
@@ -169,14 +174,13 @@ class Transcriber:
             writer = csv.writer(csvfile)
             writer.writerow(csv_columns)
             writer.writerows(data.items())
-            print(f"Wrote transcriptions for {len(data)} audio files to {report_file_name}")
+            logging.debug(f"Wrote transcriptions for {len(data)} audio files to {report_file_name}")
 
         reference_file_name = self.config.getValue("Transcriptions", "reference_transcriptions_file")
         if reference_file_name is not None:
-
             try:
                 if path.exists(reference_file_name):
-                    print(f"Found reference transcriptions file - {reference_file_name} - attempting merge with model's transcriptions")
+                    logging.debug(f"Found reference transcriptions file - {reference_file_name} - attempting merge with model's transcriptions")
 
                     file1_df = pd.read_csv(report_file_name)
                     file2_df = pd.read_csv(reference_file_name)
@@ -184,11 +188,11 @@ class Transcriber:
                     missing_columns = False
                     if not "Audio File Name" in file2_df.columns:
                         missing_columns = True
-                        print(f"Warning: 'Audio File Name' column missing in reference transcriptions file {reference_file_name}; will not merge.")
+                        logging.warning(f"'Audio File Name' column missing in reference transcriptions file {reference_file_name}; will not merge.")
 
                     if not "Reference" in file2_df.columns:
                         missing_columns = True
-                        print(f"Warning: 'Reference' column missing in reference transcriptions file {reference_file_name}; will not merge.")
+                        logging.warning(f"'Reference' column missing in reference transcriptions file {reference_file_name}; will not merge.")
 
                     if not missing_columns:
                         file2_df = file2_df[["Audio File Name", "Reference"]]
@@ -198,22 +202,17 @@ class Transcriber:
                         #print(comparison_result)
 
                         comparison_result.to_csv(report_file_name, index=False)
-                        print(f"Updated {report_file_name} with reference transcriptions")
+                        logging.debug(f"Updated {report_file_name} with reference transcriptions")
             except Exception as e:
-                print(f"Warning - Failed to merge reference transcriptions into {report_file_name}:",e)
+                logging.warning(f"Failed to merge reference transcriptions into {report_file_name}:", exc_info=e)
                 
-def main():
-    config_file = "config.ini"
-    if len(sys.argv) > 1:
-       config_file = sys.argv[1]
-    else:
-       print("Using default config filename: config.ini.")
-
-    run(config_file)
-
-def run(config_file:str):
+def run(config_file:str, logging_level:str=DEFAULT_LOGLEVEL):
     config      = Config(config_file)
     transcriber = Transcriber(config)
+
+    logging.basicConfig(level=logging_level, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    logging.debug(f"Using config file:{config_file}")
 
     audio_file_dir    = config.getValue("Transcriptions","audio_file_folder")
     max_threads   = int(config.getValue("SpeechToText","max_threads", 1))
@@ -229,4 +228,12 @@ def run(config_file:str):
     transcriber.report()
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-c', '--config', type=str, default=DEFAULT_CONFIG_INI, help='the config file to use')
+    parser.add_argument(
+        '-ll', '--log-level', type=str, default=DEFAULT_LOGLEVEL, help='the log level to use')
+
+    args = parser.parse_args()
+
+    run(args.config, args.log_level)


### PR DESCRIPTION
Aims to satisfy https://github.com/IBM/watson-stt-wer-python/issues/27 by allowing `experiment.py` to loop through STT settings and run transcription experiments for each configuration. 

1. The updates to the README should hopefully explain how `experiments.py` works now. If not, feedback welcome and I'll make changes to README. 
1. Standardized logging for `experiments.py`, `transcribe.py` and `analyze.py`. I took some liberties deciding what log level the existing `print()` lines should be, so again feedback welcome. 
1. Added two command line parameter flags to `experiments.py`, `transcribe.py` and `analyze.py`. I matched the one common flag `-c`/`--config_file` with what exists in `models.py` today. 

Each experiment outputs the following with the default log level of `INFO`:
```
2022-12-21 16:09:50,860 - INFO - Running Experiment -- Character Insertion Bias: 0.0, Customization Weight: 0.0, Speech Detector Sensitivity: 0.5, Background Audio Suppression: 0.0
2022-12-21 16:09:58,324 - INFO - Completed transcribing 4 files out of 4
2022-12-21 16:09:58,326 - INFO - Wrote transcriptions for 4 audio files to ./sample-files/0.0_0.0_0.5_0.0/stt_transcriptions.csv
2022-12-21 16:09:58,336 - INFO - Updated ./sample-files/0.0_0.0_0.5_0.0/stt_transcriptions.csv with reference transcriptions
2022-12-21 16:09:58,338 - INFO - Wrote detailed results to ./sample-files/0.0_0.0_0.5_0.0/sample-details.csv
2022-12-21 16:09:58,339 - INFO - Wrote summary results to ./sample-files/0.0_0.0_0.5_0.0/sample-summary.json
2022-12-21 16:09:58,339 - INFO - Wrote word accuracy results to ./sample-files/0.0_0.0_0.5_0.0/sample-accuracy.csv
2022-12-21 16:09:58,339 - INFO - Experiment Complete 
```

Note that `2022-12-21 16:09:58,324 - INFO - Completed transcribing 4 files out of 4` is a status message dependent on the number of files to transcribe. The script is configured to print out a status message every 100 files and at the final completion of all files. e.g. if there are 410 files there will be 5 messages total (4 in progress messages and the final total)

DCO 1.1 Signed-off-by: Gregory Ecock - [gecock@ibm.com](mailto:gecock@ibm.com)