### PR TITLE
Adding support for sclite analysis to experiments.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ The following parameters in `[Experiments]` all have a `*_min` and `*_max` varia
 1. `cust_weight_*` controls the `customization_weight` parameter
 1. `bas_*` controls the `background_audio_suppression`parameter
 
+Note: If you want to use `sclite` for analysis of each experiment be sure to configure `sclite_directory` under the `[ErrorRateOutput]` section.
+
 ## Execution
 
 ```
@@ -182,7 +184,7 @@ python experiment.py --config_file config.ini --log_level INFO
 See [Generic Command Line Parameters](#generic-command-line-parameters) for more details.
 
 ## Results
-Each experiment creates a unique directory based on the parameters of that experiment in the format `bias + "_" + weight + "_" + sds + "_" + bas`.
+Each experiment creates a unique directory based on the parameters of that experiment in the format `bias_<bias-value>_weight_<customization-weight-value>_sds_<sds-value>_bas_<bas-value>`.
 
 For each experiment the output files from [Transcribing](#transcription) and [Analyzing](#analysis) will be created in its unique output directory. 
 

--- a/experiment.py
+++ b/experiment.py
@@ -42,7 +42,7 @@ class Experiments:
 
                         logging.info(f"Running Experiment -- Character Insertion Bias: {bias}, Customization Weight: {weight}, Speech Detector Sensitivity: {sds}, Background Audio Suppression: {bas}")
 
-                        experiment_output_dir = self.output_dir + "/bias_" + str(bias) + "_weight" + str(weight) + "_sds" + str(sds) + "_bas" + str(bas)
+                        experiment_output_dir = self.output_dir + "/bias_" + str(bias) + "_weight_" + str(weight) + "_sds_" + str(sds) + "_bas_" + str(bas)
                         os.makedirs(experiment_output_dir, exist_ok=True)
 
                         exp_config_path = experiment_output_dir + "/" + self.config.config_file

--- a/experiment.py
+++ b/experiment.py
@@ -42,7 +42,7 @@ class Experiments:
 
                         logging.info(f"Running Experiment -- Character Insertion Bias: {bias}, Customization Weight: {weight}, Speech Detector Sensitivity: {sds}, Background Audio Suppression: {bas}")
 
-                        experiment_output_dir = self.output_dir + "/" + str(bias) + "_" + str(weight) + "_" + str(sds) + "_" + str(bas)
+                        experiment_output_dir = self.output_dir + "/bias_" + str(bias) + "_weight" + str(weight) + "_sds" + str(sds) + "_bas" + str(bas)
                         os.makedirs(experiment_output_dir, exist_ok=True)
 
                         exp_config_path = experiment_output_dir + "/" + self.config.config_file

--- a/experiment.py
+++ b/experiment.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 import transcribe
 import analyze
+import optional_analyze_with_sclite
 
 DEFAULT_CONFIG_INI='config.ini'
 DEFAULT_LOGLEVEL='INFO'
@@ -83,31 +84,40 @@ class Experiments:
                         transcribe.run(exp_config_path, logging_level)
 
                         #Get Analysis
-                        analyze.run(exp_config_path, logging_level)
+                        if exp_config.getValue('ErrorRateOutput', 'sclite_directory') is None:
+                            analyze.run(exp_config_path, logging_level)
+                        else:
+                            optional_analyze_with_sclite.run(exp_config_path, logging_level)
 
                         logging.info(f"Experiment Complete \n")
-
-
-
 
     def run_report(self, output_dir, config):
         logging.debug(f"Generating summary report in {output_dir}")
 
         # Extract all summaries
-        wer_summary_filename = os.path.split(config.getValue("ErrorRateOutput", "summary_file"))[1]
-        summary_tuples = []
+        if config.getValue('ErrorRateOutput', 'sclite_directory') is None:
+            lines = True 
+            wer_summary_filename = os.path.split(config.getValue("ErrorRateOutput", "summary_file"))[1]
+        else:
+            lines = False
+            wer_summary_filename = 'sclite_wer_summary.json'
+            
         summary_files = glob.glob(f"{output_dir}/**/*{wer_summary_filename}")
-        for file in summary_files:
-            with open(file) as json_file:
-                summary_tuples.append(json.load(json_file))
 
-        # Open summary file for writing
         output_filename = output_dir + '/all_summaries.csv'
-        with open(output_filename, 'w') as data_file:
-            dict_writer = csv.DictWriter(data_file, fieldnames=summary_tuples[0].keys())
-            dict_writer.writeheader()
-            dict_writer.writerows(summary_tuples)
-            logging.info(f"Wrote consolidated summary to {output_filename}")
+
+        f = open(summary_files[0])
+        data = json.load(f)
+        df_all = pd.read_json(json.dumps(data), orient='records', lines=lines)
+
+        for file in summary_files[1:]:
+            f = open(file)
+            data = json.load(f)
+            df = pd.read_json(json.dumps(data), orient='records', lines=lines)
+            df_all = pd.concat([df_all, df], ignore_index=True)
+        
+        logging.info("\n"+df_all.to_markdown())
+        df_all.to_csv(output_filename, index=False)
 
 def drange(start, stop, step):
     r = start
@@ -125,9 +135,6 @@ def run(config_file:str, logging_level:str=DEFAULT_LOGLEVEL):
     output_dir = os.path.dirname(config.getValue("ErrorRateOutput", "summary_file"))
     if output_dir is None or len(output_dir) == 0:
         output_dir = "."
-    #print(output_dir)
-
-    #run_all_experiments(config_file, output_dir)
 
     # build generators
     experiments = Experiments(config, output_dir)


### PR DESCRIPTION
Added the option to `experiment.py` to use `optional_analysis_with_sclite.py` for the experiments. If `sclite_directory` is set in the `config.ini` file then `sclite` will be used for analysis when `experiment.py` is run.

I also removed unused logic from `optional_analysis_with_sclite.py`.


Resolves https://github.com/IBM/watson-stt-wer-python/issues/68

