### PR TITLE
fix logging string for custom transaction

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -135,7 +135,7 @@ class Transcriber:
             new_headers=self.STT.default_headers
             new_headers['X-Global-Transaction-Id']=transaction_id
             self.STT.set_default_headers(new_headers)
-            logging.deubg("--> Transaction ID:", self.STT.default_headers['X-Global-Transaction-Id'])
+            logging.debug("--> Transaction ID: " + self.STT.default_headers['X-Global-Transaction-Id'])
 
         #print(f"Requesting transcription of {filename}")
         with open(filename, "rb") as audio_file:


### PR DESCRIPTION
There is a bug in the way the custom transaction ID is being logged, which this PR should fix.


Signed-off-by: Gregory Ecock <gecock@us.ibm.com>