### PR TITLE
ensure stm creation only pulls filename and reference from reference file

### DIFF
--- a/optional_analyze_with_sclite.py
+++ b/optional_analyze_with_sclite.py
@@ -50,7 +50,7 @@ class Analyzer:
             try:
                 if os.path.exists(reference_file_name):
                     logging.debug(f"Found reference transcriptions file - {reference_file_name} - attempting to create stm file")
-                    ref_df = pd.read_csv(reference_file_name)
+                    ref_df = pd.read_csv(reference_file_name, usecols = ['Audio File Name','Reference'])
                     ref_df = ref_df.sort_values(by = 'Audio File Name')
                     ref_df.insert(1,"num1",pd.Series([1 for x in range(len(ref_df.index))]))
                     ref_df.insert(2,"num2",pd.Series([0 for x in range(len(ref_df.index))]))


### PR DESCRIPTION
Currently, if a reference file has more than just `Audio File Name` and `Reference` columns then the `stm` file will inheret the extra data rendering it invalid. This PR aims to remedy that by only grabbing those two columns when it reads in the reference file during `stm` creation.

Signed-off-by: Gregory Ecock <gecock@us.ibm.com>