### PR TITLE
remove newlines to fix windows csv creation issue

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -111,7 +111,7 @@ class AnalysisResults:
     def write_details(self, filename):
         csv_columns = self.headers
 
-        with open(filename, 'w') as csvfile:
+        with open(filename, 'w',newline='') as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(csv_columns)
             for result in self.results:
@@ -129,7 +129,7 @@ class AnalysisResults:
     def write_word_accuracy(self, filename):
         csv_columns = ['word','count','errors','error_rate']
 
-        with open(filename, 'w') as csvfile:
+        with open(filename, 'w',newline='') as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
             writer.writeheader()
             for word in self.word_map:


### PR DESCRIPTION
Resolves #77 

While running on Windows extra newline characters are being added to the CSV creations of `analyze.py` causing extra rows in the file. Explicitly set the newline to `''` per https://docs.python.org/3/library/functions.html#open-newline-parameter so that the string is not converted to contain newlines.