### PR TITLE
merge on base name; warn if mismatches

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -206,9 +206,60 @@ class Transcriber:
                     if not missing_columns:
                         file2_df = file2_df[["Audio File Name", "Reference"]]
 
-                        # Perform outer join merge
-                        comparison_result = pd.merge(file1_df,file2_df, on='Audio File Name', how='outer')
-                        #print(comparison_result)
+                        # Normalize filenames for matching (use basename to handle path differences)
+                        file1_df['_match_key'] = file1_df['Audio File Name'].apply(os.path.basename)
+                        file2_df['_match_key'] = file2_df['Audio File Name'].apply(os.path.basename)
+                        
+                        # Track original counts for validation
+                        transcription_count = len(file1_df)
+                        reference_count = len(file2_df)
+                        
+                        # Perform merge on normalized basename
+                        comparison_result = pd.merge(
+                            file1_df, file2_df,
+                            on='_match_key',
+                            how='outer',
+                            suffixes=('', '_ref')
+                        )
+                        
+                        # Consolidate Audio File Name column (prefer transcription path, fallback to reference)
+                        comparison_result['Audio File Name'] = comparison_result['Audio File Name'].fillna(
+                            comparison_result['Audio File Name_ref']
+                        )
+                        
+                        # Clean up temporary columns
+                        comparison_result = comparison_result.drop(['_match_key', 'Audio File Name_ref'], axis=1)
+                        
+                        # Reorder columns to standard format
+                        comparison_result = comparison_result[['Audio File Name', 'Transcription', 'Reference']]
+                        
+                        # Validation and warning system
+                        merged_count = len(comparison_result)
+                        missing_transcription = comparison_result['Transcription'].isna().sum()
+                        missing_reference = comparison_result['Reference'].isna().sum()
+                        successful_matches = merged_count - missing_transcription - missing_reference
+                        
+                        logging.info(f"Merge summary: {successful_matches} successful matches, "
+                                    f"{missing_reference} transcriptions without reference, "
+                                    f"{missing_transcription} references without transcription")
+                        
+                        if missing_transcription > 0 or missing_reference > 0:
+                            logging.warning(
+                                f"Filename matching issues detected! "
+                                f"Expected {reference_count} references and {transcription_count} transcriptions, "
+                                f"but only {successful_matches} matched successfully."
+                            )
+                            
+                            # Log specific unmatched files for debugging
+                            if missing_transcription > 0:
+                                unmatched_refs = comparison_result[comparison_result['Transcription'].isna()]['Audio File Name'].tolist()
+                                logging.warning(f"Reference files without transcription ({len(unmatched_refs)}): {unmatched_refs[:5]}" +
+                                              (f" ... and {len(unmatched_refs)-5} more" if len(unmatched_refs) > 5 else ""))
+                            
+                            if missing_reference > 0:
+                                unmatched_trans = comparison_result[comparison_result['Reference'].isna()]['Audio File Name'].tolist()
+                                logging.warning(f"Transcription files without reference ({len(unmatched_trans)}): {unmatched_trans[:5]}" +
+                                              (f" ... and {len(unmatched_trans)-5} more" if len(unmatched_trans) > 5 else ""))
 
                         comparison_result.to_csv(report_file_name, index=False)
                         logging.info(f"Updated {report_file_name} with reference transcriptions")


### PR DESCRIPTION
**Prompt**:
```
look at the code in transcribe.py.  often times users have a merge problem with the filenames.
The ground truth filename will say `file1.mp3` as the filename and the transcription filename will be `somefolder/file1.mp3`.  This breaks the merge... I get N lines with file name and reference only, and N lines with transcription only.

Give me some options on how to address.  The weakest form is a warning where if the merged file has more lines than the reference file (indicating filenames didn't match) but I am open to other ideas.  Can we do any automated merge for "near-hits" ?
```

**Partial reasoning**:  
After analyzing the code in [`transcribe.py`](transcribe.py), I can see the merge problem clearly. The issue occurs in the [`report()`](transcribe.py:176-218) method where:

1. **Line 240**: Transcription filenames are created with full paths: `os.path.join(audio_file_dir, f)`
2. **Line 210**: The merge uses `'Audio File Name'` as the join key
3. If the reference file has just `file1.mp3` but transcriptions have `somefolder/file1.mp3`, the merge fails to match

## Solutions (Ranked by Robustness)

### **Option 1: Normalize Filenames with Basename Matching (Recommended)**
Extract just the filename (without path) for matching, while preserving full paths in the output.

**Pros:**
- Handles most common path mismatch scenarios automatically
- No user intervention needed
- Maintains backward compatibility
- Still preserves full paths in output for reference

**Implementation approach:**
```python
# Add a normalized column for matching
file1_df['_match_key'] = file1_df['Audio File Name'].apply(os.path.basename)
file2_df['_match_key'] = file2_df['Audio File Name'].apply(os.path.basename)

# Merge on normalized key
comparison_result = pd.merge(file1_df, file2_df, on='_match_key', how='outer', 
                            suffixes=('', '_ref'))

# Handle the merged columns intelligently
comparison_result['Audio File Name'] = comparison_result['Audio File Name'].fillna(
    comparison_result['Audio File Name_ref'])
comparison_result = comparison_result.drop(['_match_key', 'Audio File Name_ref'], axis=1)
```

---

### **Option 2: Fuzzy Matching with Warnings**
Implement intelligent matching with similarity scoring for near-hits.

### **Option 3: Warning System (Your Suggested Approach)**
Detect merge failures and warn users.

## **Recommended Implementation**

I suggest **Option 1 (Basename Matching) + Option 3 (Warnings)** as the best balance:

This approach:
- ✅ Automatically handles path differences (`file1.mp3` vs `somefolder/file1.mp3`)
- ✅ Provides detailed warnings when matches fail
- ✅ Lists specific unmatched files for debugging
- ✅ Maintains backward compatibility
- ✅ Preserves full paths in the output
- ✅ No manual intervention required for common cases
